### PR TITLE
Reformatted as per CPAN::Changes::Spec

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,34 +1,36 @@
-Revision history for Perl extension App::watcher
+Revision history for Perl module App::watcher
 
-0.08
+0.08 2012-01-09
 
     - Terminate child process if SIGHUP/SIGTERM/SIGINT received.
 
-0.07
+0.07 2011-10-29
 
     - re-packaging
 
-0.06
+0.06 2011-10-29
 
     - ignore *_flymake.t(issm++)
 
-0.05
+0.05 2011-08-19
 
     - win32 patch(mattn)
 
-0.04
+    [ 0.04 not released ]
 
-    - added experimental --signal=s option(suggested by kazeburo++)
+    - added experimental --signal=s option (suggested by kazeburo++)
     - added experimental --send_only option
     - added test cases(in xt/)
 
-0.03
+0.03 2011-08-19
 
     - rewrite code...
 
-0.02
+0.02 2011-08-19
 
     - fix path
 
-0.01    Fri Aug 19 18:48:44 2011
+0.01 2011-08-19
+
     - original version
+


### PR DESCRIPTION
Added missing dates.

It looks like you didn't release 0.04, so it's flagged as such, essentially making it part of 0.05.
