### PR TITLE
Fix to validate with relative file path

### DIFF
--- a/bin/watcher
+++ b/bin/watcher
@@ -114,7 +114,7 @@ sub finalize {
 
 sub valid_file {
     my ($file) = @_;
-    File::Spec->abs2rel($file) !~ m!^\.|[/\\][\._]|\.bak$|~$|_flymake\.(?:p[lm]|t)!;
+    File::Spec->abs2rel($file) !~ m!^\.[^\.]|[/\\][\._][^\.]|\.bak$|~$|_flymake\.(?:p[lm]|t)!;
 }
 
 __END__


### PR DESCRIPTION
I think the subroutine `valid_file` should validate a file with relative path for considering following situation.

Given that `/home/myuser/.ghq/myuser/repo/` is working directory and I launch `watcher` at that point,
current `watcher` implementation judges `/home/myuser/.ghq/myuser/repo/test.pl` as invalid file path
because the directory starts with "dot" exists in the path, in despite of it's located in upper directory.

This pull request is intended to fix the above situation by validating with relative file path.
